### PR TITLE
Store images in subfolders

### DIFF
--- a/functions/src/events/new-img-for-user.ts
+++ b/functions/src/events/new-img-for-user.ts
@@ -38,7 +38,9 @@ const newImgForUser = async (snapshot: QueryDocumentSnapshot, context: functions
 
   // Upload to user's storage provicer
   functions.logger.info(`${imageId} has passed all checks. Uploading.`);
-  await user.uploadImageToStorageProvider(`${imageId}.${ext}`, cropped);
+  const subfolder = user.singleFolder ? '' : `${redditPost.subreddit}/`;
+  const filename = `${subfolder}${imageId}.${ext}`;
+  await user.uploadImageToStorageProvider(filename, cropped);
 };
 
 export default newImgForUser;

--- a/functions/src/types/User.ts
+++ b/functions/src/types/User.ts
@@ -6,6 +6,7 @@ export default class User {
   dropboxToken?: string;
   maxAge!: number;
   id!: string;
+  singleFolder = true;
   private dropboxClient: DropboxClient;
 
   constructor(tokens: any) {
@@ -34,6 +35,7 @@ export default class User {
     logger.info(`${snapshots.size} image(s) marked for deletion.`);
 
     const filenames = snapshots.docs.map((d) => d.data().id).map((id) => `/${id}.jpg`);
+    // TODO: Feature: upload-into-subfolders: This will fail if user has enabled subfolders
     await this.deleteImagesFromStorageProvider(filenames);
 
     const batch = firestore().batch();


### PR DESCRIPTION
In Peppermint v2, users can choose to receive images from more than 1 subreddit.
(By default, it's still only r/earthporn)

But, images all end up in the same folder. This PR tracks a feature where users also have the option of having the images uploaded to a separate folder for each subreddit.